### PR TITLE
feat: add guiding principles for contributing to the handbook

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -5,10 +5,32 @@
 This section will guide you through the process of setting up your
 development environment, installing dependencies, and building the documentation.
 
-Below are some common questions to help you find the right guidance for specific
-contributing tasks.
+## Contributing Principles
+
+The Lab Handbook is a community-driven effort, and we welcome contributions from everyone. Here are some principles we follow when reviewing and approving contributions:
+
+#### By the lab, for the lab
+
+- Pages can be **created, edited, and reviewed** by anyone in the lab
+- Every page is **understandable** by anyone in the lab
+- **Maintenance and upkeep** is a responsibility shared by **everyone** in the lab 
+
+#### KISS - Keep It Simple, Stupid
+(or Keep It Short and Simple)
+
+- We strive to keep the handbook **focused** and **concise** to make it easy for anyone to understand
+- We **avoid unnecessary complexity**
+
+#### DRY - Don't Repeat Yourself
+- Saves **time** and **energy**
+- If details already exist on another page or website, **link to it**, don’t copy paste
+- When making a page, remember it might get referred to somewhere else!
+
+
 
 ## For Contributors
+Below are some common questions to help you find the right guidance for specific
+contributing tasks.
 
 ### Where should I start if I want to contribute?
 


### PR DESCRIPTION
Also moved the sentence about common questions to just under the For Contributors heading