### PR TITLE
feat: migrate Software Development educational resources

### DIFF
--- a/docs/software_development/Development_Environment/Integrated_Development_Environments/r_studio.md
+++ b/docs/software_development/Development_Environment/Integrated_Development_Environments/r_studio.md
@@ -1,0 +1,7 @@
+# RStudio
+
+RStudio is an integrated development environment (IDE) for R and Python. It includes a console, syntax-highlighting editor that supports direct code execution, and tools for plotting, history, debugging, and workspace management. RStudio is available in open source and commercial editions and runs on the desktop (Windows, Mac, and Linux). ([Source](https://posit.co/products/open-source/rstudio/))
+
+[Download RStudio](https://posit.co/products/open-source/rstudio/)
+
+[User Guides](https://education.rstudio.com/)

--- a/docs/software_development/Development_Environment/Integrated_Development_Environments/visual_studio_code.md
+++ b/docs/software_development/Development_Environment/Integrated_Development_Environments/visual_studio_code.md
@@ -1,0 +1,5 @@
+# Visual Studio Code
+
+[Download Visual Studio Code](https://code.visualstudio.com/)
+
+[Visual Studio Code documentation](https://code.visualstudio.com/docs)

--- a/docs/software_development/Development_Environment/Shells/wsl.md
+++ b/docs/software_development/Development_Environment/Shells/wsl.md
@@ -1,0 +1,5 @@
+# Windows Subsystem for Linux (WSL)
+
+Windows Subsystem for Linux (WSL) lets developers run a GNU/Linux environment -- including most command-line tools, utilities, and applications -- directly on Windows, unmodified, without the overhead of a traditional virtual machine or dual-boot setup. ([Source](https://learn.microsoft.com/en-us/windows/wsl/))
+
+[Installation](https://learn.microsoft.com/en-us/windows/wsl/install)

--- a/docs/software_development/Languages/R/Tidyverse/index.md
+++ b/docs/software_development/Languages/R/Tidyverse/index.md
@@ -180,6 +180,7 @@ the Tidyverse, also check out Posit's other useful tools like [Positron](https:/
     R.
     - Specifically, check out [this course](https://swirlstats.com/scn/getclean.html)
         for a quick (and interactive!) taste of working with `dplyr` and `tidyr`.
+- [Tidyverse style guide](https://style.tidyverse.org/) &mdash; A guide to consistent code writing in R.
 
 ### Packages
 

--- a/docs/software_development/Languages/R/index.md
+++ b/docs/software_development/Languages/R/index.md
@@ -23,6 +23,8 @@ Part of a book on software development in R (highly recommend the entire book to
 [Bioconductor Packages: Development, Maintenance, and Peer Review](https://contributions.bioconductor.org/)  
 If you are looking to build a package for Bioconductor, I heavily recommend going through these guidelines before starting as they have a rigorous approval process
 
+^^Highlighted chapters^^: [Coding Style](https://contributions.bioconductor.org/r-code.html#r-code)
+
 **Guide to data.tables**    
 [data.table in R ](https://rdatatable.gitlab.io/data.table/) supplemented with [External Guide to data.table](https://www.machinelearningplus.com/data-manipulation/datatable-in-r-complete-guide/) and [101 R data.table exercises](https://www.machinelearningplus.com/data-manipulation/101-r-data-table-exercises/)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.caret
 
 plugins:
   - redirects:                        # handles URL redirects for moved pages


### PR DESCRIPTION
Migrate links under Software Development heading in the [Educational resources](https://docs.google.com/document/d/168uqvBaHdx1Lazs_wYtnWPRiOLaFjeFfMMHaze7hqNM/edit?tab=t.0) document to their respective pages