### PR TITLE
feat: migrate bioinformatics and SQL education resources

### DIFF
--- a/docs/disciplines/Bioinformatics/.pages
+++ b/docs/disciplines/Bioinformatics/.pages
@@ -1,3 +1,6 @@
+title: Bioinformatics
+
 nav:
+  - index.md
   - 'Data Types': Data_Types
   - 'Tools': Tools

--- a/docs/disciplines/Bioinformatics/index.md
+++ b/docs/disciplines/Bioinformatics/index.md
@@ -1,4 +1,12 @@
 
-# Introduction
+# What is Bioinformatics?
 
-TODO:: Add a short description here
+**Bioinformatics**, as related to genetics and genomics, is a scientific subdiscipline that involves using computer technology to collect, store, analyze and disseminate biological data and information, such as DNA and amino acid sequences or annotations about those sequences. Scientists and clinicians use databases that organize and index such biological information to increase our understanding of health and disease and, in certain cases, as part of medical care. ([Source](https://www.genome.gov/genetics-glossary/Bioinformatics))
+
+## Introductory Resources
+
+* StatQuest with Josh Starmer \-[YouTube Channel](https://www.youtube.com/results?search_query=statquest) 
+
+* Rafael Irizzary Lectures - Professor of Applied Statistics at Harvard \- [YouTube Channel](https://www.youtube.com/user/RafalabChannel/featured)
+
+* [Modern Statistics for Modern Biology](https://www.huber.embl.de/msmb/) - digital textbook by Susan Holmes and Wolfgang Huber

--- a/docs/software_development/Languages/SQL/index.md
+++ b/docs/software_development/Languages/SQL/index.md
@@ -1,0 +1,6 @@
+# SQL
+
+Structured Query Language (SQL) is a domain-specific programming language designed for managing data held in a relational database management system.
+
+[What is SQL?](https://www.w3schools.com/sql/)
+

--- a/docs/software_development/Languages/index.md
+++ b/docs/software_development/Languages/index.md
@@ -4,9 +4,9 @@ Ideas for a breakdown:
 
 ## Programming Languages
 
-- R
-- Python
-- JavaScript/Typescript
+- [R](R/index.md)
+- [Python](Python/index.md)
+- [JavaScript/TypeScript](Javascript_Typescript/index.md)
 - Rust
 
 ## Scripting Languages
@@ -21,7 +21,7 @@ Ideas for a breakdown:
 
 - Definition
 - Examples
-    - SQL
+    - [SQL](SQL/index.md)
     - HTML
 
 ## Compiled vs. Interpreted Languages


### PR DESCRIPTION
Migrate links under Bioinformatics and SQL heading in the [Educational resources](https://docs.google.com/document/d/168uqvBaHdx1Lazs_wYtnWPRiOLaFjeFfMMHaze7hqNM/edit?tab=t.0) document to their respective pages