### PR TITLE
docs: add Free/Busy calendar convention to BHKLab Calendar page

### DIFF
--- a/docs/General/Communications/bhklab_calendar.md
+++ b/docs/General/Communications/bhklab_calendar.md
@@ -13,3 +13,15 @@ Your BHKLab Gmail account will be added to the BHKLab Calendar as part of your O
     You should see an email like the one below including the link to add the calendar to your Google Calendar.
 
     ![](img/bhklab_calendar_invite_email.png){width=90%}
+
+## Event Availability (Free/Busy)
+
+When creating or updating events in the BHKLab Calendar:
+
+* Mark any BHKLab events that BHK is not attending as **"Free"** rather than **"Busy"**.
+* Mark away-time events (e.g., vacation, conference travel, or other absences) as **"Free"**.
+
+These settings keep everyone's availability accurate and avoid scheduling conflicts.
+
+To set this in Google Calendar: open the event → change availability from
+**Busy** to **Free** → **Save**.

--- a/docs/General/Meetings/index.md
+++ b/docs/General/Meetings/index.md
@@ -32,3 +32,9 @@ Starting March 2026, the lab has moved to project-specific meetings considering 
 
 ## Meeting frequency of project-specific meetings
 Once or twice a month or as required by project leads.
+
+
+
+--8<--
+docs/General/Communications/bhklab_calendar.md:17:27
+--8<--


### PR DESCRIPTION
Adds an "Event Availability (Free/Busy)" section to the BHKLab Calendar page,
covering events BHK isn't attending and away-time events.

Closes #326