### PR TITLE
fix: update homepage link to remove latest

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,7 +51,7 @@ plugins:
   - table-reader                      # allows to directly insert various table formats into a page
 
 extra:
-  homepage: https://bhklab.github.io/handbook/latest
+  homepage: https://bhklab.github.io/handbook/General/
   social:
     #######################################################################################
     # https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-footer/#social-links


### PR DESCRIPTION
Note: when checking that this update works, you have to navigate back to the local serve each time you click on the icon. It's going to take you to the published site which will look like it's still broken if you click the home icon a second time.